### PR TITLE
Typo in table

### DIFF
--- a/6.17 NEO Blockchain Challenge - London.md
+++ b/6.17 NEO Blockchain Challenge - London.md
@@ -64,8 +64,8 @@ Listed below is a table of functionality that should be implemented. Each team m
 
 | Information                                                | Estimated Difficulty | Hint                                                         |
 | :--------------------------------------------------------- | :------------------- | ------------------------------------------------------------ |
-| P2P service status of NEO nodes                            | ★★★★                 | Whether nodes provide JSON-RPC services on port 10331 and 10332 |
-| RPC service status of NEO nodes                            | ★★★                  | Whether nodes provide P2P services via TCP/IP (10333), and P2P services via WebSocket (10334). |
+| P2P service status of NEO nodes                            | ★★★★                 | Whether nodes provide P2P services via TCP/IP (10333), and P2P services via WebSocket (10334). |
+| RPC service status of NEO nodes                            | ★★★                  |  Whether nodes provide JSON-RPC services on port 10331 and 10332	|
 | Stability of NEO nodes                                     | ★★★                  | If a node is offline for 10 minutes per day, the stability is<br/>`1 - 10/(60*24) = 99.3%` |
 | Version information of NEO nodes                           | ★★                   | http://docs.neo.org/en-us/node/cli/api/getversion.html       |
 | Current block height of NEO nodes                          | ★★                   | http://docs.neo.org/en-us/node/cli/api/getblockcount.html    |


### PR DESCRIPTION
RPC and P2P should be swapped in the hint text.
The left column of the first row mentions P2P but then the hint is for JSON-RPC and vice versa for the next row.